### PR TITLE
refactor: resolve warnings

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -40,6 +40,7 @@
 #include "os.h"
 
 #include "constants.h"
+#include "sw.h"
 
 bool address_from_pubkey(const uint8_t public_key[static 33],
                          uint8_t *out,
@@ -52,9 +53,18 @@ bool address_from_pubkey(const uint8_t public_key[static 33],
         return false;
     }
 
-    cx_ripemd160_init(&ctx);
+    if (cx_ripemd160_init_no_throw(&ctx) != CX_OK) {
+        return false;
+    }
 
-    cx_hash((cx_hash_t *) &ctx, CX_LAST, public_key, PUBLIC_KEY_LEN, address, ADDRESS_HASH_LEN);
+    if (cx_hash_no_throw((cx_hash_t *) &ctx,
+                         CX_LAST,
+                         public_key,
+                         PUBLIC_KEY_LEN,
+                         address,
+                         ADDRESS_HASH_LEN) != CX_OK) {
+        return false;
+    }
 
     memmove(out + 1, address, ADDRESS_HASH_LEN - 1);
     out[0] = network;

--- a/src/context.c
+++ b/src/context.c
@@ -9,6 +9,8 @@
 
 #include <string.h>  // explicit_bzero
 
+#include "os.h"  // PRINTF
+
 #include "globals.h"
 
 void reset_app_context() {

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -73,13 +73,17 @@ int crypto_sign_message() {
     // derive private key according to BIP32 path
     crypto_derive_private_key(&private_key, NULL, G_context.bip32_path, G_context.bip32_path_len);
 
-    if (cx_ecschnorr_sign_no_throw(&private_key,
-                                   CX_ECSCHNORR_BIP0340 | CX_RND_TRNG,
-                                   CX_SHA256,
-                                   G_context.tx_info.m_hash,
-                                   sizeof(G_context.tx_info.m_hash),
-                                   G_context.tx_info.signature,
-                                   &signature_len) != CX_OK) {
+    cx_err_t error = cx_ecschnorr_sign_no_throw(&private_key,
+                                                CX_ECSCHNORR_BIP0340 | CX_RND_TRNG,
+                                                CX_SHA256,
+                                                G_context.tx_info.m_hash,
+                                                sizeof(G_context.tx_info.m_hash),
+                                                G_context.tx_info.signature,
+                                                &signature_len);
+
+    explicit_bzero(&private_key, sizeof(private_key));
+
+    if (error != CX_OK) {
         return -1;
     }
 


### PR DESCRIPTION
The Nano SDKs from LedgerHQ recently deprecated several functions.

This was revealed during recent unrelated updates and resulted in a static analysis CI workflow failure.

This PR proposes using LedgerHQ's newest `_no_throw` functions and getting rid of the related try-catch patterns.

---

more info:
- related CI failure: https://github.com/Solar-network/ledger-app-solar/actions/runs/5881600155
- getting rid of try-catch info _(ledger app-boilerplate)_: https://github.com/LedgerHQ/app-boilerplate/commit/4c99dff95b3cead536ee663ae2476b7f0dec45f0

---

_Please note that the functional test workflow also fails as a result of recent external changes._
_This is addressed in a separate PR (#5)._