### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,13 @@
 src/glyphs.c
 src/glyphs.h
 bin/
+build/
 debug/
 dep/
 obj/
 
 # Unit tests and code coverage
+tests/functional/snapshots-tmp/
 tests/unit-tests/build/
 tests/unit-tests/coverage/
 tests/unit-tests/coverage.info


### PR DESCRIPTION
This PR proposes updating the repo's `.gitignore` to exclude files created during the build and testing processes, which will help prevent these auto-generated files from being unintentionally committed.

---

_Please note that there are currently CI workflow failures as a result of recent external changes._
_These are addressed in separate PRs (#4 and #5)._